### PR TITLE
Added openid auth example

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -122,10 +122,59 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
+    "@types/body-parser": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.1.tgz",
+      "integrity": "sha512-RoX2EZjMiFMjZh9lmYrwgoP9RTpAjSHiJxdp4oidAQVO02T7HER3xj9UKue5534ULWeqVEkujhWcyvUce+d68w==",
+      "requires": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/connect": {
+      "version": "3.4.32",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.32.tgz",
+      "integrity": "sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/express": {
+      "version": "4.17.2",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.2.tgz",
+      "integrity": "sha512-5mHFNyavtLoJmnusB8OKJ5bshSzw+qkMIBAobLrIM48HJvunFva9mOa6aBwh64lBFyNwBbs0xiEFuj4eU/NjCA==",
+      "requires": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "@types/express-serve-static-core": {
+      "version": "4.16.11",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.11.tgz",
+      "integrity": "sha512-K8d2M5t3tBQimkyaYTXxtHYyoJPUEhy2/omVRnTAKw5FEdT+Ft6lTaTOpoJdHeG+mIwQXXtqiTcYZ6IR8LTzjQ==",
+      "requires": {
+        "@types/node": "*",
+        "@types/range-parser": "*"
+      }
+    },
+    "@types/keycloak-connect": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@types/keycloak-connect/-/keycloak-connect-4.5.1.tgz",
+      "integrity": "sha512-ioHJ+cZ3r8tfiaP/7aZv1ZJjx3WIA6bwexap7aTa5ioQDiLLHnJzwSeUZNfFm1Cj4J4KVsDsDBy33cY3iaelmg==",
+      "requires": {
+        "@types/express": "*"
+      }
+    },
     "@types/long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.0.tgz",
       "integrity": "sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q=="
+    },
+    "@types/mime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
+      "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw=="
     },
     "@types/node": {
       "version": "10.14.21",
@@ -148,6 +197,20 @@
       "resolved": "https://registry.npmjs.org/@types/pino-std-serializers/-/pino-std-serializers-2.4.0.tgz",
       "integrity": "sha512-eAdu+NW1IkCdmp85SnhyKha+OOREQMT9lXaoICQxa7bhSauRiLzu3WSNt9Mf2piuJvWeXF/G0hGWHr63xNpIRA==",
       "dev": true
+    },
+    "@types/range-parser": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
+      "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
+    },
+    "@types/serve-static": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.3.tgz",
+      "integrity": "sha512-oprSwp094zOglVrXdlo/4bAHtKTAxX6VT8FOZlBKrmyLbNvE1zxZyJ6yikMVtHIvwP45+ZQGJn+FdXGKTozq0g==",
+      "requires": {
+        "@types/express-serve-static-core": "*",
+        "@types/mime": "*"
+      }
     },
     "@types/sonic-boom": {
       "version": "0.7.0",
@@ -185,6 +248,16 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "asn1.js": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+      "requires": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
     "async-limiter": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
@@ -217,6 +290,11 @@
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
       }
+    },
+    "bn.js": {
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
     },
     "body-parser": {
       "version": "1.19.0",
@@ -258,6 +336,11 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -361,6 +444,20 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
+    "elliptic": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.1.tgz",
+      "integrity": "sha512-xvJINNLbTeWQjrl6X+7eQCrIy/YPv5XCpKW6kB5mKvtnGILoLDcySuwomfdzt0BMdLNVnuRNTuzKNHj0bva1Cg==",
+      "requires": {
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
+      }
+    },
     "end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -436,6 +533,25 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    },
+    "hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+      "requires": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
     },
     "http-errors": {
       "version": "1.7.2",
@@ -535,6 +651,24 @@
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
     },
+    "jwk-to-pem": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwk-to-pem/-/jwk-to-pem-2.0.1.tgz",
+      "integrity": "sha512-KKu0WuDDjqw2FlRFp9/vk9TMO/KvgpZVKzdhhYcNyy5OwE8dw9lOK5OQTQHIJ7m+HioI/4P44sAtVuDrQ8KQfw==",
+      "requires": {
+        "asn1.js": "^4.5.2",
+        "elliptic": "^6.2.3",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "keycloak-connect": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/keycloak-connect/-/keycloak-connect-7.0.1.tgz",
+      "integrity": "sha512-JC5IPlm6TbWfK7xrD/Ef3QQRvuldR2teudbdKCTHo1+NcVmSlKVUeip2drttjUo/JUpQ1DjfpdZB/xMfqnEv5g==",
+      "requires": {
+        "jwk-to-pem": "^2.0.0"
+      }
+    },
     "leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -572,6 +706,16 @@
       "requires": {
         "mime-db": "1.40.0"
       }
+    },
+    "minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+    },
+    "minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
     },
     "minimatch": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "@deepstream/protobuf": "^1.0.1",
     "@deepstream/server": "^5.0.1",
     "@deepstream/types": "^2.0.6",
+    "@types/keycloak-connect": "^4.5.1",
     "ioredis": "^4.14.1",
+    "keycloak-connect": "^7.0.1",
     "pino": "^5.13.5"
   },
   "devDependencies": {

--- a/src/openid/config.yml
+++ b/src/openid/config.yml
@@ -1,0 +1,7 @@
+auth:
+  - path: ./openid/openid-authentication
+    options:
+    # base url used by keycloak connect to validate the token
+    keycloakBaseUrl: https://localhost:8080/auth
+    # keycloak realm to validate against.
+    keycloakRealm: example-realm

--- a/src/openid/deepstream-config.ts
+++ b/src/openid/deepstream-config.ts
@@ -1,0 +1,3 @@
+import { Deepstream } from '@deepstream/server'
+const deepstream = new Deepstream('./config.yml')
+deepstream.start()

--- a/src/openid/deepstream-constructor.ts
+++ b/src/openid/deepstream-constructor.ts
@@ -1,0 +1,13 @@
+import { Deepstream } from '@deepstream/server'
+
+export const deepstream = new Deepstream({
+    auth: [{
+        path: './openid/openid-authentication',
+        options: {
+            keycloakBaseUrl: "",
+            keycloakRealm: ""
+        }
+    }]
+})
+
+deepstream.start()

--- a/src/openid/deepstream-setter.ts
+++ b/src/openid/deepstream-setter.ts
@@ -1,0 +1,8 @@
+import OpenidAuthentication from './openid-authentication'
+import { Deepstream } from '@deepstream/server'
+
+const deepstream = new Deepstream({})
+
+deepstream.set('auth', new OpenidAuthentication({ keycloakBaseUrl: "", keycloakRealm: "" }, deepstream.getServices()))
+
+deepstream.start()

--- a/src/openid/openid-authentication.ts
+++ b/src/openid/openid-authentication.ts
@@ -1,0 +1,111 @@
+import { DeepstreamPlugin, DeepstreamServices, DeepstreamAuthentication, DeepstreamAuthenticationResult, EVENT } from '@deepstream/types'
+import { TokenContent } from "keycloak-connect";
+import Keycloak = require('keycloak-connect');
+import { Request, Response } from 'express';
+
+interface OpenidAuthenticationOptions {
+    keycloakRealm: string;
+    keycloakBaseUrl: string;
+}
+
+interface ExtentedTokenContent extends TokenContent {
+    scope: string;
+    email_verified: boolean;
+    name: string;
+    preferred_username: string;
+    given_name: string;
+    family_name: string;
+    email: string;
+}
+
+/**
+ * auth plugin for deepstream, that uses a regular access token to decide about authentication
+ */
+export default class OpenidAuthentication extends DeepstreamPlugin implements DeepstreamAuthentication {
+    public description = 'Openid Authentication'
+    private logger = this.services.logger.getNameSpace('OPENID AUTH')
+
+    private keycloak: Keycloak;
+
+    constructor(private options: OpenidAuthenticationOptions, private services: Readonly<DeepstreamServices>) {
+        super()
+        this.keycloak = new Keycloak(
+            {},
+            {
+                realm: options.keycloakRealm,
+                "bearer-only": true,
+                "auth-server-url": options.keycloakBaseUrl,
+                "ssl-required": "external",
+                resource: "deepstream",
+                "confidential-port": 0,
+            }
+        );
+    }
+
+    /**
+     * The only API callback required for authentication.
+     * 
+     * The callback signature is as follows:
+     * 
+     * If user is found:
+     * 
+     * return {
+     *  isValid: boolean,
+     *  id: uuid,
+     *  clientData: {}, // data to send to client on login or login error
+     *  serverData: {} // data used to authenticate users
+     * }
+     * 
+     * // If user is not found, return null
+     * return null
+     * 
+     * The username is the name to be used by permissions as well as presence. It doesn't have to be unique, but
+     * if more than one user with the same name is logged in the system doesn't behave any differently! So if you want
+     * each user to be unique you may need to add a uuid to distinguish between them.
+     * 
+     * serverData is data that can be accessed throughout deepstream (mostly via permissioning and custom plugins) incase
+     * you want more context about the actual client
+     * 
+     * clientData is returned to the client after a succesful login. This could be a token to allow them to login again
+     * without entering sensitive information or their favourite color preferences. However, it's worth noting that it's
+     * always recommended to use records because they are dynamic! ClientData should usually be login related, like session
+     * expiry time or such.
+     */
+
+    async isValidUser(connectionData: any, authData: any): Promise<DeepstreamAuthenticationResult | null> {
+        this.logger.info(`isValidUser connectionData=${JSON.stringify(connectionData)}`);
+
+        if (typeof authData.token !== 'string') {
+            this.logger.warn(EVENT.AUTH_ERROR, "authData must contain token as string");
+            return null
+        }
+        // in order to validate  the token with keycloak, we create a fake request / response to use the
+        // regular keycloak lib creating a grant
+        let responseCode = 0;
+        const fakeReq = { headers: { authorization: authData.token, } };
+        const fakeRes = { status: (code: number) => { responseCode = code; }, end: () => { } };
+
+        let grant: Keycloak.Grant | null = null;
+        try {
+            grant = await this.keycloak.getGrant(fakeReq as Request, fakeRes as Response);
+        } catch (e) {
+            this.logger.warn(EVENT.AUTH_ERROR, "could not get grant from token: " + JSON.stringify(e));
+        }
+        if (grant && responseCode === 0) {
+            // if token is valid, we use the token content as userId
+            // and put to whole token into server data for creating permissions based on token later
+            const extToken = grant.access_token.content as ExtentedTokenContent;
+            this.logger.info(EVENT.INFO, "login sucessful, token valid");
+            return {
+                isValid: true,
+                id: extToken.preferred_username,
+                serverData: { grant: JSON.stringify(grant) },
+                clientData: undefined,
+            };
+        }
+
+        // If an invalid token is provided then return null incase another auth
+        // handler can save the day
+        return null
+    }
+}


### PR DESCRIPTION
Added an example of authentication using an openid access token. Token gets validated and grant is provided as "server data" as a basis for permissions in a permission plugin.

Uses the keycloak-connect client library but should work with every compliant openid server, not just keycloak